### PR TITLE
Don't run Chromatic for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build:icons
       - run: yarn chromatic --exit-once-uploaded --exit-zero-on-changes
+        if: github.actor != 'dependabot[bot]'
         working-directory: storybook/
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
We're hitting a test limit on Chromatic, so this change disables Chromatic tests for Dependabot PRs. This is okay since we'll commit a changeset commit from a human for any release, which will be tested by Chromatic.